### PR TITLE
Update validator.yml

### DIFF
--- a/roles/analog-node/tasks/validator.yml
+++ b/roles/analog-node/tasks/validator.yml
@@ -20,7 +20,7 @@
         version: '3'
         services:
             analog:
-                image: analoglabs/timechain:latest
+                image: analoglabs/timenode-test:latest
                 container_name: '{{ docker_name }}'
                 command:
                     [


### PR DESCRIPTION
change the docker image source to the one advised by analog team. I am unsure whether this image will change in the future